### PR TITLE
Don't manipulate empty cookie headers

### DIFF
--- a/default.vcl
+++ b/default.vcl
@@ -118,28 +118,31 @@ sub vcl_recv {
   }
 
   # Some generic cookie manipulation, useful for all templates that follow
-  # Remove the "has_js" cookie
-  set req.http.Cookie = regsuball(req.http.Cookie, "has_js=[^;]+(; )?", "");
-
-  # Remove any Google Analytics based cookies
-  set req.http.Cookie = regsuball(req.http.Cookie, "__utm.=[^;]+(; )?", "");
-  set req.http.Cookie = regsuball(req.http.Cookie, "_ga=[^;]+(; )?", "");
-  set req.http.Cookie = regsuball(req.http.Cookie, "_gat=[^;]+(; )?", "");
-  set req.http.Cookie = regsuball(req.http.Cookie, "utmctr=[^;]+(; )?", "");
-  set req.http.Cookie = regsuball(req.http.Cookie, "utmcmd.=[^;]+(; )?", "");
-  set req.http.Cookie = regsuball(req.http.Cookie, "utmccn.=[^;]+(; )?", "");
-
-  # Remove DoubleClick offensive cookies
-  set req.http.Cookie = regsuball(req.http.Cookie, "__gads=[^;]+(; )?", "");
-
-  # Remove the Quant Capital cookies (added by some plugin, all __qca)
-  set req.http.Cookie = regsuball(req.http.Cookie, "__qc.=[^;]+(; )?", "");
-
-  # Remove the AddThis cookies
-  set req.http.Cookie = regsuball(req.http.Cookie, "__atuv.=[^;]+(; )?", "");
-
-  # Remove a ";" prefix in the cookie if present
-  set req.http.Cookie = regsuball(req.http.Cookie, "^;\s*", "");
+  # Don't manipulate empty cookies
+  if (req.http.Cookie !~ "^\s*$") {
+    # Remove the "has_js" cookie
+    set req.http.Cookie = regsuball(req.http.Cookie, "has_js=[^;]+(; )?", "");
+  
+    # Remove any Google Analytics based cookies
+    set req.http.Cookie = regsuball(req.http.Cookie, "__utm.=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "_ga=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "_gat=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "utmctr=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "utmcmd.=[^;]+(; )?", "");
+    set req.http.Cookie = regsuball(req.http.Cookie, "utmccn.=[^;]+(; )?", "");
+  
+    # Remove DoubleClick offensive cookies
+    set req.http.Cookie = regsuball(req.http.Cookie, "__gads=[^;]+(; )?", "");
+  
+    # Remove the Quant Capital cookies (added by some plugin, all __qca)
+    set req.http.Cookie = regsuball(req.http.Cookie, "__qc.=[^;]+(; )?", "");
+  
+    # Remove the AddThis cookies
+    set req.http.Cookie = regsuball(req.http.Cookie, "__atuv.=[^;]+(; )?", "");
+  
+    # Remove a ";" prefix in the cookie if present
+    set req.http.Cookie = regsuball(req.http.Cookie, "^;\s*", "");
+  }
 
   # Are there cookies left with only spaces or that are empty?
   if (req.http.cookie ~ "^\s*$") {


### PR DESCRIPTION
  
After running the cookie manipulations from the `default.vcl`, `varnishtop` showed that accessing empty cookies from the request header was always coming out on top of `VCL_return`:

```
5503.83 ReqHeader      Cookie:
 872.25 VCL_return     deliver
```

That seemed strange and after some digging around, I noticed that it's the `set req.http.Cookie = regsuball(req.http.Cookie, "...", "")` cookie removals on empty cookie headers. Apparently a lot of bots/crawlers like to send empty cookie headers. Looking at `varnishlog` for a request with `Cookie:` confirms it:

```
...
-   ReqHeader      cookie: 
...
-   VCL_call       RECV
...
-   ReqUnset       cookie: 
-   ReqHeader      Cookie: 
-   ReqUnset       Cookie: 
-   ReqHeader      Cookie: 
-   ReqUnset       Cookie: 
...
```

Skipping the replacements for empty headers fixed this. 